### PR TITLE
Fix V719 warning from PVS-Studio Static Analyzer

### DIFF
--- a/amf.cc
+++ b/amf.cc
@@ -229,6 +229,9 @@ void amf_write(Encoder *enc, const AMFValue &value)
 	case AMF_NULL:
 		amf_write_null(enc);
 		break;
+        case AMF_UNDEFINED:
+                /* Do nothing */
+                break;
 	}
 }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The switch statement does not cover all values of the 'AMFType' enum:
AMF_UNDEFINED.