### PR TITLE
Fix V595 warning from PVS-Studio Static Analyzer

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -763,7 +763,9 @@ void do_poll()
 				try_to_send(client);
 			} catch (const std::runtime_error &e) {
 				printf("client error: %s\n", e.what());
-				close_client(client, i);
+                                if (client) {
+                                    close_client(client, i);
+                                }
 				--i;
 				continue;
 			}


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The 'client' pointer was utilized before it was verified against nullptr